### PR TITLE
convert signed to unsigned modbus reg

### DIFF
--- a/devices/modbus.js
+++ b/devices/modbus.js
@@ -113,6 +113,10 @@ module.exports = class extends EventEmitter {
                                 regValue = await this.controller.read(['hr', item.register].join(''))
                                 // console.log(`<<<<<<<<<<<<<<<<<<<<<<item.register ${item.register} regValue: ${regValue}`)
                             }
+                            if(regValue < 0){
+                                //convert 16 bit signed int to 16 bit unsigned int
+                                regValue = regValue + 65536
+                            }
                         } else {
                             await this.wait(200);
                             regValue = this.commsStatus

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edge-router",
-  "version": "1.1.35",
+  "version": "1.1.36",
   "description": "edge-router",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Had issue with Graham on site. He writes a large value to modbus-blackbox register. This is written as a UInt 16bit but the issue was when reading the value it gets converted to a signed 16 bit. So on read we convert it.